### PR TITLE
Add Timeout-related Workaround

### DIFF
--- a/libirc.py
+++ b/libirc.py
@@ -315,7 +315,8 @@ class IRCConnection:
                     return False
                 except socket.timeout as e:
                     try:
-                        self.quit('Operation timed out.', wait=False)
+                        timeout_threshold = self.sock.gettimeout()
+                        self.quit('Operation timed out after %s seconds.' % timeout_threshold, wait=False)
                     finally:
                         self.sock = None
                     raise

--- a/libirc.py
+++ b/libirc.py
@@ -283,58 +283,59 @@ class IRCConnection:
 
     def recv(self, block=True):
         '''Receive stream from server.\nDo not call it directly, it should be called by parse() or recvline().'''
-        if self.recvlock.acquire():
+        if not self.recvlock.acquire():
+            if block:
+                raise threading.ThreadError('Cannot acquire lock.')
+            else:
+                return False
+
+        try:
+            if not self.sock:
+                e = socket.error(
+                    '[errno %d] Socket operation on non-socket' % errno.ENOTSOCK)
+                e.errno = errno.ENOTSOCK
+                raise e
             try:
-                if not self.sock:
-                    e = socket.error(
-                        '[errno %d] Socket operation on non-socket' % errno.ENOTSOCK)
-                    e.errno = errno.ENOTSOCK
-                    raise e
-                try:
-                    if block:
-                        received = self.sock.recv(self.buffer_length)
-                    else:
-                        oldtimeout = self.sock.gettimeout()
-                        self.sock.settimeout(0)
-                        try:
-                            if isinstance(self.sock, ssl.SSLSocket):
-                                received = self.sock.recv(self.buffer_length)
-                            else:
-                                received = self.sock.recv(
-                                    self.buffer_length, socket.MSG_DONTWAIT)
-                        finally:
-                            self.sock.settimeout(oldtimeout)
-                            del oldtimeout
-                    if received:
-                        self.recvbuf += received
-                    else:
-                        self.quit('Connection reset by peer.', wait=False)
-                    return True
-                except (ssl.SSLWantReadError, ssl.SSLWantWriteError) as e:
-                    # can be a subclass of socket.error
-                    return False
-                except socket.timeout as e:
+                if block:
+                    received = self.sock.recv(self.buffer_length)
+                else:
+                    oldtimeout = self.sock.gettimeout()
+                    self.sock.settimeout(0)
                     try:
-                        timeout_threshold = self.sock.gettimeout()
-                        self.quit('Operation timed out after %s seconds.' % timeout_threshold, wait=False)
+                        if isinstance(self.sock, ssl.SSLSocket):
+                            received = self.sock.recv(self.buffer_length)
+                        else:
+                            received = self.sock.recv(
+                                self.buffer_length, socket.MSG_DONTWAIT)
+                    finally:
+                        self.sock.settimeout(oldtimeout)
+                        del oldtimeout
+                if received:
+                    self.recvbuf += received
+                else:
+                    self.quit('Connection reset by peer.', wait=False)
+                return True
+            except (ssl.SSLWantReadError, ssl.SSLWantWriteError) as e:
+                # can be a subclass of socket.error
+                return False
+            except socket.timeout as e:
+                try:
+                    timeout_threshold = self.sock.gettimeout()
+                    self.quit('Operation timed out after %s seconds.' % timeout_threshold, wait=False)
+                finally:
+                    self.sock = None
+                raise
+            except socket.error as e:
+                if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    return False
+                else:
+                    try:
+                        self.quit('Network error.', wait=False)
                     finally:
                         self.sock = None
                     raise
-                except socket.error as e:
-                    if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                        return False
-                    else:
-                        try:
-                            self.quit('Network error.', wait=False)
-                        finally:
-                            self.sock = None
-                        raise
-            finally:
-                self.recvlock.release()
-        elif block:
-            raise threading.ThreadError('Cannot acquire lock.')
-        else:
-            return False
+        finally:
+            self.recvlock.release()
 
     def recvline(self, block=True):
         '''Receive a raw line from server.\nIt calls recv(), and is called by parse() when line==None.\nIts output can be the 'line' argument of parse()'s input.'''


### PR DESCRIPTION
Sometimes, @m13253/ircbindxmpp mysteriously disconnects from the server. This is a known issue of unknown reason for a long time. Now, the cause of this issue has been identified, the issue is caused by a underlying design problem in libirc.

## How it Happens

If there's a lot of messages from XMPP, but no message from IRC for 5 minutes, `ircbindxmpp` will
disconnect the server, with message *Quit: Operation timed out.*

## Why it Happens

`IRCConnecct.recv` is responsible for receiving messages from the IRC server. If nothing is received
from the server for a long (`self.sock.settimeout(300)`) time,  `self.sock.recv(self.buffer_length)` will raise a timeout error, and `self.quit()` is called.

`300` seconds is a reasonable threshold for timeout, since it is the normal interval of PING from the
server. However, the server will PING the client **iff** the client is not active, it is the case for most IRC bots and no issues will be shown.

However, `ircbindxmpp` is a message forwarding bot, in this case, a design problem of `recv()` function is exposed: since the client keeps sending message to the server, the IRC server won't send any PING messages, and `recv()` won't be able to read anything from the server and it triggers a timeout error and quit.

## How to Workaround

This commit add a hack to workaround this problem. We put the receive logic in a big loop that runs only once, but if a `socket.timeout` is encountered, the program will PING itself, and reset the loop to the start, and a counter "retry" is increased by one. The "retry" counter is cleared after we received data this time.

If socket.timeout is encountered again and we have tried too many times, the program will quit, like the original behavior. The advantage of this hack is, that it doesn't require any API changes.